### PR TITLE
Python 3.7 and 3.8 compatibility update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ python setup.py build --inplace
 > radius = 481 # How big a circle your fisheye image is in pixels
 > center = [618, 538] # Center of your fisheye image
 > scale = 0.5 # How big the resulting pano is compared to the original
-> mypano = fish2pano(myimg, radius, center, scale) # numpy array of your new pano image 
+> mypano = fish2pano.fish2pano(myimg, radius, center, scale) # numpy array of your new pano image
 ```
 
 # Command Line and Graphical tools

--- a/fish2pano/__init__.py
+++ b/fish2pano/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import math
 import traceback
+from typing import Tuple
 
 import numpy as np
 import time
@@ -43,7 +44,7 @@ def generate_pano_pure(img_raw, radius, center, scale):
     return img_t
 
 
-def fish2pano(img_raw: np.ndarray, radius: float, center: list[int, int], scale: float):
+def fish2pano(img_raw: np.ndarray, radius: float, center: Tuple[int, int], scale: float):
     """
     Generate panoramic image.
     :param img_raw: image to make pano from, uint8 numpy array with shape (w, h, 3)


### PR DESCRIPTION
Python 3.7 and 3.8 do not support built-in collection as type hints for lists and tuples (with parameters)